### PR TITLE
add-admin-role

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "npx prisma generate && next build",
+    "build": "npx prisma generate && npx prisma migrate deploy && next build",
     "start": "next start",
     "lint": "next lint"
   },

--- a/prisma/migrations/20250616202026_add_user_role/migration.sql
+++ b/prisma/migrations/20250616202026_add_user_role/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "UserRole" AS ENUM ('USER', 'ADMIN');
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "role" "UserRole" NOT NULL DEFAULT 'USER';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,11 +19,17 @@ enum AccessLevel {
   PREMIUM
 }
 
+enum UserRole {
+  USER
+  ADMIN
+}
+
 model User {
   id        String             @id @default(cuid())
   email     String             @unique
   name      String?
   image     String?
+  role      UserRole           @default(USER)
   createdAt DateTime           @default(now())
   updatedAt DateTime           @updatedAt
   companies CompaniesOnUsers[]

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,10 @@
+export default function AdminDashboardPage() {
+  return (
+    <div>
+      <h1 className="text-3xl font-bold">Super Admin Dashboard</h1>
+      <p className="mt-2">This area is for managing companies and users.</p>
+
+      {/* Forms for creating companies and users will go here */}
+    </div>
+  );
+}

--- a/src/app/api/analytics/route.ts
+++ b/src/app/api/analytics/route.ts
@@ -4,61 +4,81 @@ import { auth } from '../../../auth';
 import { type Session } from 'next-auth';
 import { BetaAnalyticsDataClient } from '@google-analytics/data';
 import { NextRequest, NextResponse } from 'next/server';
+import prisma from '@/../lib/prisma';
 
 const client_email = process.env.GA_CLIENT_EMAIL;
 const private_key = process.env.GA_PRIVATE_KEY?.replace(/\\n/g, '\n');
 
 export async function GET(req: NextRequest) {
-
   const session = (await auth()) as Session;
-  // Get companyId from the request URL (e.g., /api/analytics?companyId=...)
   const requestedCompanyId = req.nextUrl.searchParams.get('companyId');
 
   if (!requestedCompanyId) {
     return new NextResponse('Company ID is required.', { status: 400 });
   }
 
-  // Find the selected company in the user's list of companies
-  const selectedCompany = session.user?.companies?.find(c => c.id === requestedCompanyId);
+  const isSuperAdmin = session.user?.role === 'ADMIN';
+  const assignedCompany = session.user?.companies?.find(c => c.id === requestedCompanyId);
+  
+  if (!isSuperAdmin && !assignedCompany) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
 
-  // Security: Ensure the requested company belongs to the user and has a gaPropertyId
-  const propertyId = selectedCompany?.gaPropertyId;
+  // 3. Get the propertyId based on the user's role.
+  let propertyId: string | null | undefined;
+  if (isSuperAdmin) {
+    // If admin, fetch the company details directly from the database.
+    const companyFromDb = await prisma.company.findUnique({
+      where: { id: requestedCompanyId },
+      select: { gaPropertyId: true }
+    });
+    propertyId = companyFromDb?.gaPropertyId;
+  } else {
+    // If regular user, get it from their session object.
+    propertyId = assignedCompany?.gaPropertyId;
+  }
 
+  // Final check to ensure we have a propertyId (we always should, ga4 ID will be a required field when adding a client in admin dashboard).
   if (!propertyId) {
-    return new NextResponse('Unauthorized or Google Analytics Property ID not found.', {
-      status: 401,
+    return new NextResponse('Google Analytics Property ID not found for this company.', {
+      status: 404,
     });
   }
+
   const analyticsDataClient = new BetaAnalyticsDataClient({
-    credentials: {
-      client_email,
-      private_key,
-    },
+    credentials: { client_email, private_key },
   });
 
   try {
     const [response] = await analyticsDataClient.runReport({
       property: `properties/${propertyId}`,
-      dateRanges: [
-        {
-          startDate: '30daysAgo',
-          endDate: 'today',
-        },
-      ],
+      dateRanges: [{ startDate: '30daysAgo', endDate: 'today' }],
       metrics: [{ name: 'activeUsers' }, { name: 'newUsers' }],
       dimensions: [{ name: 'deviceCategory' }],
     });
 
     const analyticsData =
       response.rows?.map((row) => ({
-        country: row.dimensionValues?.[0].value,
+        deviceCategory: row.dimensionValues?.[0].value,
         activeUsers: row.metricValues?.[0].value,
         newUsers: row.metricValues?.[1].value,
       })) || [];
 
     return NextResponse.json(analyticsData, { status: 200 });
   } catch (error) {
-    console.error('Error fetching Google Analytics data:', error);
-    return new NextResponse('Error fetching Google Analytics data', { status: 500 });
+    let errorMessage = 'An unknown error occurred while fetching analytics data.';
+      if (error instanceof Error) {
+        // The Google API client often puts more specific details in a `details` property
+        if ('details' in error && typeof (error as { details: string }).details === 'string') {
+            errorMessage = (error as { details: string }).details;
+        } else {
+            errorMessage = error.message;
+        }
+    }
+
+    console.error('Error fetching Google Analytics data:', errorMessage);
+    return new NextResponse(`Error fetching Google Analytics data: ${errorMessage}`, { status: 500 });
   }
+
+  
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,77 +1,49 @@
-'use client';
-import { useState, useEffect } from 'react'; // Import useEffect
-import { signOut, useSession } from 'next-auth/react';
-import { AnalyticsDashboard } from '../../components/AnalyticsDashboard';
-import Image from 'next/image';
+// src/app/dashboard/page.tsx
 
-export default function DashboardPage() {
-  const { data: session } = useSession();
+import { auth } from '@/auth'; // Server-side auth
+import { redirect } from 'next/navigation';
+import prisma from '@/../lib/prisma'; // Server-side DB access
+import DashboardClient from '@/components/dashboard/DashboardClient'; // Your new client component
+import { type Company } from '../../../generated/prisma';
 
-  const [selectedCompanyId, setSelectedCompanyId] = useState<string | null>(null);
+// This is now an async Server Component
+export default async function DashboardPage() {
+  // 1. Get session on the server
+  const session = await auth();
 
-  const firstName = session?.user?.name?.split(' ')[0] || 'User';
-  const companies = session?.user?.companies ?? [];
+  // Redirect to home if not logged in (should never happen due to middleware, but just in case)
+  if (!session?.user) {
+    redirect('/');
+  }
 
-    // If there's no selected company yet and the user has companies,
-    // set the first one as the default, otherwise it will be null on load.
-  useEffect(() => {
-    if (!selectedCompanyId && companies.length > 0) {
-      setSelectedCompanyId(companies[0].id);
+  let companies: Company[] = [];
+  const userName = session.user.name ?? null;
+
+  // 2. Check the user's role and fetch companies accordingly
+  if (session.user.role === 'ADMIN') {
+    // If user is an ADMIN, fetch ALL companies from the database
+    companies = await prisma.company.findMany({
+      orderBy: { name: 'asc' },
+    });
+  } else {
+    // For regular users, use the companies assigned in their session
+    companies = (session.user.companies as Company[]) ?? [];
+
+    // Redirect regular users if they have no company (this should be handled by middleware, but we ensure it here)
+    if (companies.length === 0) {
+      redirect('/wait');
     }
-  }, [companies, selectedCompanyId]);
+  }
 
+  // 3. Determine the initial company to display
+  const initialCompanyId = companies[0]?.id ?? null;
+
+  // 4. Render the Client Component and pass the data as props
   return (
-    <main className="flex min-h-screen flex-col p-4">
-      <div className="header">
-        <div>
-          <h1 className="text-2xl font-bold mb-4">Welcome, {firstName}!</h1>
-          <p className="">You&apos;re looking very handsome today. </p>
-
-          {companies.length > 1 && (
-            <div className="mt-4">
-              <label htmlFor="company-select" className="block text-sm font-medium text-gray-300">
-                Select a Company:
-              </label>
-              <select
-                id="company-select"
-                value={selectedCompanyId ?? ''}
-                onChange={(e) => setSelectedCompanyId(e.target.value)}
-                className="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-600 bg-gray-800 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md"
-              >
-                {companies.map((company) => (
-                  <option key={company.id} value={company.id}>
-                    {company.name}
-                  </option>
-                ))}
-              </select>
-            </div>
-          )}
-        </div>
-        <div className="logo">
-          <Image alt="dykstra hamel logo" src="/dykstra-hamel-logo.svg" width={300} height={50} />
-        </div>
-        <button
-          onClick={() => signOut({ callbackUrl: '/' })}
-          style={{
-            padding: '10px 15px',
-            backgroundColor: '#dc3545',
-            color: 'white',
-            border: 'none',
-            width: '150px',
-            height: '50px',
-            borderRadius: '5px',
-            cursor: 'pointer',
-          }}>
-          Sign Out
-        </button>
-      </div>
-          
-      {selectedCompanyId ? (
-        <AnalyticsDashboard selectedCompanyId={selectedCompanyId} />
-      ) : (
-        <div>Loading...</div>
-      )}
- 
-    </main>
+    <DashboardClient
+      companies={companies}
+      initialCompanyId={initialCompanyId}
+      userName={userName}
+    />
   );
 }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -29,6 +29,7 @@ export const {
         if (dbUser) {
           token.id = dbUser.id;
           token.companies = dbUser.companies.map((c) => c.company);
+          token.role = dbUser.role; 
         }
       }
       return token;
@@ -44,6 +45,7 @@ export const {
       if (session.user) {
         session.user.id = token.id as string;
         session.user.companies = token.companies;
+         session.user.role = token.role;
       }
       return session;
     },

--- a/src/components/dashboard/AnalyticsDashboard.tsx
+++ b/src/components/dashboard/AnalyticsDashboard.tsx
@@ -20,11 +20,10 @@ import {
 
 // Define the structure of our analytics data
 interface AnalyticsData {
-  country: string;
+  deviceCategory: string; // Correct property name
   activeUsers: string;
   newUsers: string;
 }
-
 interface AnalyticsDashboardProps {
   selectedCompanyId: string;
 }
@@ -73,11 +72,11 @@ export function AnalyticsDashboard({ selectedCompanyId }: AnalyticsDashboardProp
   "var(--chart-5)",
 ];
 
-  const chartData =  data?.map((item, index) => ({
-    Country: item.country,
-    visitors: parseInt(item.activeUsers, 10),
-    fill: colorPalette[index % colorPalette.length],
-  }));
+const chartData =  data?.map((item, index) => ({
+  deviceCategory: item.deviceCategory,
+  visitors: parseInt(item.activeUsers, 10),
+  fill: colorPalette[index % colorPalette.length],
+}));
 
   const chartConfig = {
     visitors: {
@@ -129,7 +128,7 @@ export function AnalyticsDashboard({ selectedCompanyId }: AnalyticsDashboardProp
               cursor={false}
               content={<ChartTooltipContent hideLabel />}
             />
-            <Pie data={chartData} dataKey="visitors" nameKey="Country" />
+            <Pie data={chartData} dataKey="visitors" nameKey="deviceCategory" />
           </PieChart>
         </ChartContainer>
       </CardContent>

--- a/src/components/dashboard/DashboardClient.tsx
+++ b/src/components/dashboard/DashboardClient.tsx
@@ -1,0 +1,77 @@
+// src/components/DashboardClient.tsx
+
+'use client';
+
+import { useState, useEffect } from 'react';
+import { signOut } from 'next-auth/react';
+import { AnalyticsDashboard } from './AnalyticsDashboard';
+import Image from 'next/image';
+import { type Company } from '../../../generated/prisma';
+ // Import the Company type
+
+// Define the props this component will receive from the server
+interface DashboardClientProps {
+  companies: Company[];
+  initialCompanyId: string | null;
+  userName: string | null;
+  // You can also pass initialAnalyticsData if you are pre-fetching it
+}
+
+export default function DashboardClient({ companies, initialCompanyId, userName }: DashboardClientProps) {
+  const [selectedCompanyId, setSelectedCompanyId] = useState<string | null>(initialCompanyId);
+
+  const firstName = userName?.split(' ')[0] || 'User';
+
+  // This effect ensures the first company is selected if the props load after initial render
+  useEffect(() => {
+    if (!selectedCompanyId && companies.length > 0) {
+      setSelectedCompanyId(companies[0].id);
+    }
+  }, [companies, selectedCompanyId]);
+
+  return (
+    <main className="flex min-h-screen flex-col p-4">
+      <div className="header">
+        <div>
+          <h1 className="text-2xl font-bold mb-4">Welcome, {firstName}!</h1>
+          <p className="">You&apos;re looking very handsome today. </p>
+
+          {/* The dropdown will now display ALL companies for an admin */}
+          {companies.length > 1 && (
+            <div className="mt-4">
+              <label htmlFor="company-select" className="block text-sm font-medium text-gray-300">
+                Select a Company:
+              </label>
+              <select
+                id="company-select"
+                value={selectedCompanyId ?? ''}
+                onChange={(e) => setSelectedCompanyId(e.target.value)}
+                className="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-600 bg-gray-800 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md"
+              >
+                {companies.map((company) => (
+                  <option key={company.id} value={company.id}>
+                    {company.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+        </div>
+        <div className="logo">
+          <Image alt="dykstra hamel logo" src="/dykstra-hamel-logo.svg" width={300} height={50} />
+        </div>
+        <button
+          onClick={() => signOut({ callbackUrl: '/' })}
+          style={{ padding: '10px 15px', backgroundColor: '#dc3545', color: 'white', border: 'none', width: '150px', height: '50px', borderRadius: '5px', cursor: 'pointer' }}>
+          Sign Out
+        </button>
+      </div>
+
+      {selectedCompanyId ? (
+        <AnalyticsDashboard selectedCompanyId={selectedCompanyId} />
+      ) : (
+        <div>Loading...</div>
+      )}
+    </main>
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,8 +6,19 @@ import { auth } from './auth';
 export default auth((req) => {
   const { auth } = req;
   const isLoggedIn = !!auth;
+  const userRole = auth?.user?.role
   const userHasCompany = !!auth?.user.companies?.length;
   const { pathname } = req.nextUrl;
+
+    const isAccessingAdminRoute = pathname.startsWith('/admin');
+  if (isAccessingAdminRoute) {
+    if (userRole !== 'ADMIN') {
+      // Redirect non-admins away from admin routes
+      return NextResponse.redirect(new URL('/dashboard', req.url));
+    }
+    // Allow admins to proceed
+    return NextResponse.next();
+  }
 
   // Check if the user is trying to access a protected route
   const isAccessingProtectedRoute = pathname.startsWith('/dashboard');

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -2,11 +2,12 @@
 
 import { type DefaultSession, type User as DefaultUser } from "next-auth";
 import { type JWT as DefaultJWT } from "next-auth/jwt";
-import { type Company } from "@prisma/client";
+import { type Company, type UserRole } from "@prisma/client";
 
 declare module "next-auth" {
   interface User extends DefaultUser {
     companies: Company[];
+        role: UserRole;
   }
 
   interface Session extends DefaultSession {
@@ -18,5 +19,6 @@ declare module "next-auth/jwt" {
   /** Returned by the `jwt` callback and `auth`, when using JWT sessions */
   interface JWT extends DefaultJWT {
     companies: Company[];
+    role: UserRole;
   }
 }


### PR DESCRIPTION
- Added admin role on User table in db. enum for ADMIN or USER. default is USER.
- added Prisma script to build scripts in package.json so the production build will always deploy the new schema SQL
- added basic /admin page and protected in middleware, only User with ADMIN role can access.
- Admin role will get ALL companies from DB to populate their drop down of available clients on dashboard, Users will still get their companies from session.
- refactored Dashboard component to be server component, with a Client component being added for the user interactive stuff.
